### PR TITLE
Allow dependency chaining on DNS validation rather than the certificate creation

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "acm_certificate_arn" {
   description = "arn of acm certificate"
-  value       = "${aws_acm_certificate.this.arn}"
+  value       = "${var.validation_method == "DNS" ? aws_acm_certificate_validation.dns_validation.*.certificate_arn[0] : aws_acm_certificate.this.arn}"
 }
 
 output "acm_certificate_dns_validation_record" {


### PR DESCRIPTION
Given resource dependencies on an ACM certificate:
`
module "foo" {
    source              = "github.com/traveloka/terraform-aws-acm-certificate"
  domain_name         = "host.some.fqdn"
  hosted_zone_name    = "some.fqdn"
  is_hosted_zone_private = "false"
  validation_method   = "DNS"
  certificate_name    = "host-some-fqdn"
  environment         = "test"
  description         = "TLS certificate for host.some.fqdn"
  product_domain      = "product-name"
  providers {
    aws = "aws.us-east-1"
  }
}

resource "aws_some_resource_that_needs_acm" "foo" {
  foo = "foo"
  bar = "bar"
  certificate_arn = "${module.foo.acm_certificate_arn}|
}
`
Dependency fails, because the certificate is not validated, and thus not issued.
This PR returns the ACM certificate arn from the validator if the validation is DNS, allowing dependencies to be fulfilled. 