### PR TITLE
functional san support

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -2,3 +2,9 @@ data "aws_route53_zone" "zone" {
   name         = "${var.hosted_zone_name}"
   private_zone = "false"
 }
+
+data "aws_route53_zone" "san-zones" {
+  count        = "${length(local.san_fqdns)}"
+  name         = "${lookup(var.san_map, local.san_fqdns[count.index])}"
+  private_zone = "false"
+}

--- a/examples/dns_validation/main.tf
+++ b/examples/dns_validation/main.tf
@@ -1,5 +1,5 @@
 module "acm" {
-  source = "../../"
+  source           = "../../"
   domain_name      = "*.stg-tvlk.cloud"
   hosted_zone_name = "stg-tvlk.cloud"
   certificate_name = "wildcard.stg-tvlk.cloud"

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 resource "aws_acm_certificate" "this" {
   domain_name       = "${var.domain_name}"
   validation_method = "DNS"
+  subject_alternative_names = "${local.san_fqdns}"
 
   tags = {
     Name          = "${var.certificate_name}"
@@ -19,7 +20,22 @@ resource "aws_route53_record" "this" {
   ttl     = 60
 }
 
+locals {
+  san_fqdns = "${keys(var.san_map)}"
+  verification_fqdn_list = [ "${aws_route53_record.this.fqdn}", "${local.san_fqdns}" ] 
+}
+
+resource "aws_route53_record" "this-san" {
+  count = "${length(local.san_fqdns)  }"
+  # count.index +1 because the first one is the primary fqdn/validation
+  name    = "${lookup(aws_acm_certificate.this.domain_validation_options[ count.index + 1 ], "resource_record_name")}"
+  type    = "${lookup(aws_acm_certificate.this.domain_validation_options[ count.index + 1 ], "resource_record_type")}"
+  zone_id = "${data.aws_route53_zone.san-zones.*.id[ count.index ]}"
+  records    = ["${lookup(aws_acm_certificate.this.domain_validation_options[ count.index + 1 ], "resource_record_value")}" ]
+  ttl     = 60
+}
+
 resource "aws_acm_certificate_validation" "dns_validation" {
   certificate_arn         = "${aws_acm_certificate.this.arn}"
-  validation_record_fqdns = ["${aws_route53_record.this.fqdn}"]
+  validation_record_fqdns = [ "${aws_route53_record.this.fqdn}", "${aws_route53_record.this-san.*.fqdn}"]
 }

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 resource "aws_acm_certificate" "this" {
-  domain_name       = "${var.domain_name}"
-  validation_method = "DNS"
+  domain_name               = "${var.domain_name}"
+  validation_method         = "DNS"
   subject_alternative_names = "${local.san_fqdns}"
 
   tags = {
@@ -9,6 +9,11 @@ resource "aws_acm_certificate" "this" {
     Environment   = "${var.environment}"
     Description   = "${var.description}"
     ManagedBy     = "terraform"
+  }
+
+  #on account of time it takes to validate acm at times, creating before destroying seems like a good idea
+  lifecycle {
+    create_before_destroy = true
   }
 }
 
@@ -21,21 +26,22 @@ resource "aws_route53_record" "this" {
 }
 
 locals {
-  san_fqdns = "${keys(var.san_map)}"
-  verification_fqdn_list = [ "${aws_route53_record.this.fqdn}", "${local.san_fqdns}" ] 
+  san_fqdns              = "${keys(var.san_map)}"
+  verification_fqdn_list = ["${aws_route53_record.this.fqdn}", "${local.san_fqdns}"]
 }
 
 resource "aws_route53_record" "this-san" {
   count = "${length(local.san_fqdns)  }"
+
   # count.index +1 because the first one is the primary fqdn/validation
   name    = "${lookup(aws_acm_certificate.this.domain_validation_options[ count.index + 1 ], "resource_record_name")}"
   type    = "${lookup(aws_acm_certificate.this.domain_validation_options[ count.index + 1 ], "resource_record_type")}"
   zone_id = "${data.aws_route53_zone.san-zones.*.id[ count.index ]}"
-  records    = ["${lookup(aws_acm_certificate.this.domain_validation_options[ count.index + 1 ], "resource_record_value")}" ]
+  records = ["${lookup(aws_acm_certificate.this.domain_validation_options[ count.index + 1 ], "resource_record_value")}"]
   ttl     = 60
 }
 
 resource "aws_acm_certificate_validation" "dns_validation" {
   certificate_arn         = "${aws_acm_certificate.this.arn}"
-  validation_record_fqdns = [ "${aws_route53_record.this.fqdn}", "${aws_route53_record.this-san.*.fqdn}"]
+  validation_record_fqdns = ["${aws_route53_record.this.fqdn}", "${aws_route53_record.this-san.*.fqdn}"]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,3 +7,8 @@ output "acm_certificate_dns_validation_record" {
   description = "record which is used to validate acm certificate"
   value       = "${aws_route53_record.this.name}"
 }
+
+output "acm_certificate_san_dns_validation_records" {
+  description = "records which is used to validate san parts of the acm certificate"
+  value       = "${aws_route53_record.this-san.*.name}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -28,11 +28,6 @@ variable "hosted_zone_name" {
   type        = "string"
 }
 
-variable "additional_domains" {
-  type    = "map"
-  default = {}
-}
-
 variable "san_map" {
   description = "Subject Alternative Names in map{ hostname:dns-zone-name }  format"
   type        = "map"

--- a/variables.tf
+++ b/variables.tf
@@ -27,3 +27,17 @@ variable "hosted_zone_name" {
   description = "Need for DNS validation, hosted zone name where record validation will be stored."
   type        = "string"
 }
+
+variable "additional_domains" {
+  type    = "map"
+  default {
+  }
+}
+
+variable "san_map" {
+  description = "Subject Alternative Names in map{ hostname:dns-zone-name }  format"
+  type    = "map"
+  default {
+  }
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -30,14 +30,11 @@ variable "hosted_zone_name" {
 
 variable "additional_domains" {
   type    = "map"
-  default {
-  }
+  default = {}
 }
 
 variable "san_map" {
   description = "Subject Alternative Names in map{ hostname:dns-zone-name }  format"
-  type    = "map"
-  default {
-  }
+  type        = "map"
+  default     = {}
 }
-


### PR DESCRIPTION
```module "test" {
  source = "../terraform-aws-acm-certificate"

  domain_name      = "primary-fqdn.tld"
  hosted_zone_name = "primary-zone-name"

  #san map in fqdn:zone-name format
  san_map = {
    "some-fqdn.foo.bar"          = "foo.bar"
    "some-fqdn.test.foo.bar"     = "test.foo.bar"
  }

  certificate_name = "multi-host-tls-test"
  environment      = "test"
  description      = "test TLS certificate multiple hostnames"
  product_domain   = "testing"

  providers {
    aws = "aws.someprovider"
  }
```
adds new data sources to iterate over the map to allow different r53 zones.